### PR TITLE
chore: modify scan speed limit. 300 -> 100

### DIFF
--- a/src/main/java/com/blockchain/scanning/MagicianBlockchainScan.java
+++ b/src/main/java/com/blockchain/scanning/MagicianBlockchainScan.java
@@ -137,8 +137,8 @@ public class MagicianBlockchainScan {
             throw new Exception("ChainType cannot be empty");
         }
 
-        if (blockChainConfig.getScanPeriod() < 300) {
-            throw new Exception("scanPeriod must be greater than 300");
+        if (blockChainConfig.getScanPeriod() < 100) {
+            throw new Exception("scanPeriod must be greater than 100");
         }
 
         if (blockChainConfig.getChainType().equals(ChainType.ETH)


### PR DESCRIPTION
Some chains already have a block speed of over 300ms, so reduce the minimum scan speed to 100ms.